### PR TITLE
Optimize runtime

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -24,7 +24,7 @@ bootstrap: $(wildcard *.asd) $(wildcard *.lisp)
 		cl-aws-builder
 
 function.zip: bootstrap
-	2>/dev/null rm function.zip
+	rm function.zip || exit 0
 	zip function.zip bootstrap
 
 build: bootstrap
@@ -38,6 +38,9 @@ update: bootstrap function.zip
 	aws lambda update-function-code --function-name ${FUNCTION_NAME} --zip-file fileb://function.zip
 invoke:
 	aws lambda invoke --function-name ${FUNCTION_NAME} --payload '{"name": "Matt"}' response.txt
+
+invoke-local:
+	docker run --rm -v "${PWD}":/var/task lambci/lambda:provided ${HANDLER} '{"name": "Wedge"}'
 
 clean-artifacts:
 	rm -f function.zip bootstrap

--- a/example/hello.lisp
+++ b/example/hello.lisp
@@ -7,9 +7,6 @@
 (defun hello (event)
   (let ((name (cdr (assoc "name" event :test #'string=))))
     (if name
-	(with-output-to-string (s)
-          (jonathan.encode:with-output (s)
-            (jonathan:with-object
-              (jojo:write-key-value "response" (format nil "Hello, ~a!" name))
-              (jojo:write-key-value "request-id" (cl-aws-lambda/runtime-interface:request-id-of cl-aws-lambda/runtime-interface:*context*)))))
+        (list (cons "response" (format nil "Hello, ~a!" name))
+              (cons "resquest-id" (cl-aws-lambda/runtime-interface:request-id-of cl-aws-lambda/runtime-interface:*context*)))
 	(error "No name supplied!"))))

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -37,12 +37,5 @@
 	 (*lambda-task-root* (uiop:getenv "LAMBDA_TASK_ROOT"))
          (*lambda-runtime-dir* (uiop:getenv "LAMBDA_RUNTIME_DIR")))
 
-     (log:debug "Environment:
-  _HANDLER: ~a
-  LAMBDA_TASK_ROOT: ~a" *handler* *lambda-task-root*)
      (check-environment)
-
-     ;; This prevents errors about Syscall poll(2)
-     (uiop:chdir *lambda-runtime-dir*)
-
      ,@body))

--- a/src/runtime-interface.lisp
+++ b/src/runtime-interface.lisp
@@ -126,7 +126,10 @@ For example, Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sa
     ;; This retry is an attempt to handle the errors making syscall poll(2) that
     ;; seem to happen when the process is unfrozen by the lambda runtime.
     (handler-bind ((simple-error (logged-retry)))
-      (multiple-value-bind (body status headers) (dex:get (make-runtime-url "runtime/invocation/next"))
+      (multiple-value-bind (body status headers) (dex:get (make-runtime-url "runtime/invocation/next")
+                                                          ;; saves 20+ms
+                                                          :keep-alive nil)
+        (declare (type fixnum status))
         (assert (= status 200) nil "The runtime interface returned a value of ~d, the body of the response was: ~S" status body)
 
         (values (jojo:parse body :as :alist) (make-context headers))))))
@@ -152,7 +155,9 @@ For example, Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sa
   (assert *context* nil "Tried to report an invocation error but *context* was unbound.")
 
   (dex:post (make-runtime-url "runtime/invocation/" (request-id-of *context*) "/response")
-            :content content))
+            :content content
+            ;; saves 20+ms
+            :keep-alive nil))
 
 
 (defun invocation-error (error)

--- a/src/runtime-interface.lisp
+++ b/src/runtime-interface.lisp
@@ -76,6 +76,8 @@ For example, Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sa
 (defun make-context (headers)
   "Makes a context instance out of a hash table of headers."
 
+  (declare (optimize (speed 3) (space 3) (safety 0) (compilation-speed 0)))
+
   (macrolet ((header (name) `(gethash ,(string-downcase name) headers)))
 
     (make-instance 'request-context
@@ -108,8 +110,11 @@ For example, Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sa
 (defun next-invocation ()
   "`Next Invocation <https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-next>`_."
 
+  (declare (optimize (space 3) (speed 3) (safety 1)))
+
   (flet ((logged-retry ()
            (let ((retries 0))
+             (declare (type (integer 0 5) retries))
              (lambda (e)
                (declare (type condition e))
                (when-let ((restart (find-restart 'dex:retry-request e)))
@@ -141,6 +146,8 @@ For example, Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sa
 
 (defun invocation-response (content)
   "`Invocation Response <https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-response>`_."
+
+  (declare (optimize space (speed 3) (safety 1)))
 
   (assert *context* nil "Tried to report an invocation error but *context* was unbound.")
 

--- a/src/runtime-interface.lisp
+++ b/src/runtime-interface.lisp
@@ -142,7 +142,8 @@ For example, Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sa
        do (let ((*context* ,context))
 
             ;; When the request is traced, we should set _X_AMZN_TRACE_ID so that xray libraries know the tracing info.
-            (setf (uiop:getenv "_X_AMZN_TRACE_ID") (if (sampled-p *context*) (trace-id-of *context*) ""))
+            (when (sampled-p *context*)
+              (setf (uiop:getenv "_X_AMZN_TRACE_ID") (trace-id-of *context*)))
 
 	    ,@body))))
 

--- a/src/runtime-interface.lisp
+++ b/src/runtime-interface.lisp
@@ -22,6 +22,7 @@
 
 (in-package :cl-aws-lambda/runtime-interface)
 
+
 (defvar *api-version* "2018-06-01")
 
 
@@ -73,6 +74,7 @@ For example, Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sa
                      :documentation "Lambda-Runtime-Cognito-Identity – For invocations from the AWS Mobile SDK, data about the Amazon Cognito identity provider.")))
 
 
+(declaim (inline make-context))
 (defun make-context (headers)
   "Makes a context instance out of a hash table of headers."
 
@@ -89,12 +91,14 @@ For example, Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sa
                    :cognito-identity (header "Lambda-Runtime-Cognito-Identity"))))
 
 
+(declaim (inline sampled-p))
 (defun sampled-p (context)
   (declare (type request-context context))
 
   (str:containsp "Sampled=1" (trace-id-of context)))
 
 
+(declaim (inline make-runtime-url))
 (defun make-runtime-url (&rest path-components)
   (declare (type (trivial-types:proper-list string) path-components))
   (let ((*aws-lambda-runtime-api* (uiop:getenv "AWS_LAMBDA_RUNTIME_API")))
@@ -107,10 +111,11 @@ For example, Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sa
 	    (apply #'str:concat path-components))))
 
 
+(declaim (inline next-invocation))
 (defun next-invocation ()
   "`Next Invocation <https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-next>`_."
 
-  (declare (optimize (space 3) (speed 3) (safety 1)))
+  (declare (optimize (speed 3) (space 3) (safety 0) (compilation-speed 0)))
 
   (flet ((logged-retry ()
            (let ((retries 0))
@@ -148,10 +153,11 @@ For example, Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sa
 	    ,@body))))
 
 
+(declaim (inline invocation-response))
 (defun invocation-response (content)
   "`Invocation Response <https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-response>`_."
 
-  (declare (optimize space (speed 3) (safety 1)))
+  (declare (optimize (speed 3) (space 3) (safety 0) (compilation-speed 0)))
 
   (assert *context* nil "Tried to report an invocation error but *context* was unbound.")
 

--- a/src/runtime-interface.lisp
+++ b/src/runtime-interface.lisp
@@ -156,7 +156,8 @@ For example, Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sa
   (assert *context* nil "Tried to report an invocation error but *context* was unbound.")
 
   (dex:post (make-runtime-url "runtime/invocation/" (request-id-of *context*) "/response")
-            :content content
+            :headers '((:content-type . "application/json"))
+            :content (jojo:to-json content :from :alist)
             ;; saves 20+ms
             :keep-alive nil
             ;; Seems to save around 10ms

--- a/src/runtime-interface.lisp
+++ b/src/runtime-interface.lisp
@@ -157,7 +157,9 @@ For example, Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sa
   (dex:post (make-runtime-url "runtime/invocation/" (request-id-of *context*) "/response")
             :content content
             ;; saves 20+ms
-            :keep-alive nil))
+            :keep-alive nil
+            ;; Seems to save around 10ms
+            :force-binary t))
 
 
 (defun invocation-error (error)

--- a/src/runtime.lisp
+++ b/src/runtime.lisp
@@ -47,10 +47,8 @@
     (with-environment ()
       (let ((handler-function (symbol-function (read-from-string *handler*))))
 
-        (log:debug "Using handler function ~a." *handler*)
+        (log:info "Using handler function ~a." *handler*)
 
         (do-events (event)
-          (log:debug "~&Handling event:~% ~a" event)
-
           (handling-invocation-errors ()
             (invocation-response (funcall handler-function event))))))))

--- a/src/runtime.lisp
+++ b/src/runtime.lisp
@@ -41,6 +41,8 @@
 (defun main ()
   "Main entry point that bootstraps the runtime and then invokes the handler function."
 
+  (declare (optimize space (speed 3)))
+
   (handling-intialization-errors ()
     (with-environment ()
       (let ((handler-function (symbol-function (read-from-string *handler*))))


### PR DESCRIPTION
Time is money on lambda, so I did some digging to find out what slows the runtime down.

1. Something in dex was much slower when `:keep-alive` was `t`.  It's that by default, so explicitly passing `nil` in the runtime saves upwards of 20ms per invocation.
1. Not decoding the response from submitting the result saves another 10ms.
1. Optimizing the work the runtime does heavily saves another couple ms.